### PR TITLE
Add cmigemo directories for boxen users

### DIFF
--- a/autoload/vital/_vigemo/Migemo.vim
+++ b/autoload/vital/_vigemo/Migemo.vim
@@ -31,6 +31,8 @@ function! s:_search_dict(name)
           \ '/usr/local/share/',
           \ '/usr/share/cmigemo/',
           \ '/usr/share/',
+          \ '/opt/boxen/homebrew/opt/cmigemo/share/cmigemo/',
+          \ '/opt/boxen/homebrew/opt/cmigemo/share/',
           \ ]
       let path = path . a:name
       if filereadable(path)


### PR DESCRIPTION
When using [BOXEN](https://boxen.github.com/), homebrew-installed cmigemo dictionaries are placed under `/opt/boxen/homebrew/opt/cmigemo/share/`. This pull requests adds this (and `.../share/cmigemo`) directory to search paths.
